### PR TITLE
Fix tooltip position calculations being affected by container

### DIFF
--- a/src/LollipopPlot.tsx
+++ b/src/LollipopPlot.tsx
@@ -79,7 +79,13 @@ export default class LollipopPlot extends React.Component<LollipopPlotProps, {}>
             tooltipVisibleProps.visible = false;
         }
         return (
-            <div style={{position:"relative"}} data-test="LollipopPlot">
+            <div
+                style={{
+                    position: 'relative',
+                    display: 'inline-block'
+                }}
+                data-test="LollipopPlot"
+            >
                 <DefaultTooltip
                     placement={this.handlers.getOverlayPlacement()}
                     overlay={this.handlers.getOverlay}


### PR DESCRIPTION
tooltip positioning calculations are made relative to the `div` that contains both the `DefaultTooltip` and the `LollipopPlotNoTooltip`. styles like `text-align: center` or left padding might position the SVG differently in the container with whitespace, but the whitespace won't be taken into account when the tooltip is drawn. `display: inline-block` limits the width of the container to the root SVG so it would help prevent this behavior

closes #6 